### PR TITLE
fix: A warning message of classes page

### DIFF
--- a/pages/classes/index.js
+++ b/pages/classes/index.js
@@ -97,10 +97,10 @@ export default function Classes({
           </div>
 
           {<Modal userId={user} certificationNames={certificationNames} />}
-          {classrooms.map(classrooms => (
-            <div key={classrooms.id}>
+          {classrooms.map(classroom => (
+            <div key={classroom.classroomId}>
               <ClassInviteTable
-                classes={classrooms}
+                classes={classroom}
                 certificationNames={certificationNames}
                 userId={user}
               ></ClassInviteTable>


### PR DESCRIPTION

fixed: #175

1. This warning showed because while the app is rendering an array classrooms using map function, it is using classroom.id as the key of each classroom. But there is no 'id' field in the classroom schema. There is only ‘classroomId’ field. So I used 'classroomId' instead of 'id'
<img width="900" alt="Screen Shot 2022-11-01 at 3 47 17 PM" src="https://user-images.githubusercontent.com/90477208/199377833-4a863439-7b42-4c48-ba91-54a301b215f7.png">

2. As the syntax in map function,  map((element) => { /* … */ }) , the element is the current element being processed in the array. It would be better to use classroom to refer to an element in the classrooms array.